### PR TITLE
Resolve all validation errors and fix rendering bugs

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,6 +41,7 @@ int main(int argc, char **argv)
 		ubo.time += 0.002f;
 
 		ctx.UpdateUniform(ubo);
+		ctx.Update();
 		ctx.DrawGraphics();
 		ctx.Present();
 	}

--- a/src/vulkanctx.cpp
+++ b/src/vulkanctx.cpp
@@ -346,6 +346,7 @@ bool VulkanCTX::Setup(int width, int height)
 	// Now, lets setup the swapchain!
 
 	glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
+	glfwWindowHint(GLFW_VISIBLE, GLFW_TRUE);
 	glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
 
 	window = glfwCreateWindow(width, height, "vkwaifu: waifuing edition!", nullptr, nullptr);
@@ -442,7 +443,8 @@ bool VulkanCTX::Resize() // resizes swapchain
 		}
 	}
 
-	VK_FATAL(surfaceFormat.format == VK_FORMAT_UNDEFINED, "cannot find supported format")
+	if (surfaceFormat.format == VK_FORMAT_UNDEFINED)
+		surfaceFormat = surfaceFormats[0];
 
 	uint32_t presentModeCount = 0;
 	std::vector<VkPresentModeKHR> presentModes;
@@ -459,7 +461,8 @@ bool VulkanCTX::Resize() // resizes swapchain
 		}
 	}
 
-	VK_FATAL(presentMode == 0xFF, "cannot find supported surface present mode")
+	if (presentMode == 0xFF)
+		presentMode = VK_PRESENT_MODE_FIFO_KHR;
 
 	// Create swapchain
 	VkSurfaceCapabilitiesKHR surfaceCapabilities;

--- a/src/vulkanctx.h
+++ b/src/vulkanctx.h
@@ -35,6 +35,7 @@ public:
 	void Release(); // destroys vulkanctx
 	void ResetCache(); // clears internal cache
 	void Present(); // presents to screen
+	void Update(); // update swapchain
 	void ClearCurrentImage();
 
 	void SetupGraphics(uint32_t width, uint32_t height); // Sets up Material
@@ -49,7 +50,7 @@ public:
 	inline void PollEvents() { glfwPollEvents(); }
 	inline GLFWwindow *getWindow() { return window; }
 
-	inline VkCommandBuffer getCurrentCommandBuffer() { return presentCommandBuffer; }
+	inline VkCommandBuffer getCurrentCommandBuffer() { return presentCommandBuffer[currentImage]; }
 	inline VkImage getCurrentImage() { return swapchainImages[currentImage]; }
 
 protected:
@@ -92,8 +93,8 @@ protected:
 	VkSwapchainKHR swapchain;
 	std::vector<VkImage> swapchainImages;
 	std::vector<VkImageView> swapchainImageViews;
-	VkCommandBuffer presentCommandBuffer;
-	uint32_t currentImage;
+	std::vector<VkCommandBuffer> presentCommandBuffer;
+	uint32_t currentImage, imageIndex;
 
 	VkSurfaceFormatKHR surfaceFormat;
 	VkPresentModeKHR presentMode;


### PR DESCRIPTION
This pull request fixes issues and bugs with the renderer by:
- recycling resources
- using multiple command buffers
- resolving of all validation errors
- creating and using a valid VkExtent2D for swapchain creation in the case that currentExtent.width is UINT32_MAX
- using swapchain defaults from the physical device or otherwise
- enabling samplerAnisotropy in VkPhysicalDeviceFeatures

The program should work consistently on different platforms and drivers with these changes now.
Fixes #3